### PR TITLE
Add Paraström minimal React app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Parastroem
+# Paraström
+
+
+Dieses Repository enthält eine minimalistische React-Anwendung **Paraström**. Die App erlaubt das Erfassen paralleler Tasks mit lokaler Speicherung im Browser.
+
+Starten:
+Einfach `index.html` im Browser öffnen. Es werden React und Tailwind über CDN geladen; ein Build-Schritt ist nicht nötig.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,172 @@
+const STORAGE_KEY = 'parastrom_tasks';
+
+function saveTasks(tasks) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+function loadTasks() {
+  const data = localStorage.getItem(STORAGE_KEY);
+  return data ? JSON.parse(data) : [];
+}
+
+function exportTasks(tasks) {
+  const dataStr = JSON.stringify(tasks, null, 2);
+  const blob = new Blob([dataStr], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'parastrom-tasks.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function importTasks(setTasks) {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = 'application/json';
+  input.onchange = () => {
+    const file = input.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const tasks = JSON.parse(e.target.result);
+        setTasks(tasks);
+      } catch (err) {
+        alert('Import fehlgeschlagen');
+      }
+    };
+    reader.readAsText(file);
+  };
+  input.click();
+}
+
+function TaskForm({ onAdd }) {
+  const [title, setTitle] = React.useState('');
+  const [category, setCategory] = React.useState('');
+  const [priority, setPriority] = React.useState('low');
+  const [duration, setDuration] = React.useState(1);
+  const [unit, setUnit] = React.useState('minutes');
+  const [notes, setNotes] = React.useState('');
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const multiplier = { minutes: 60000, hours: 3600000, days: 86400000 }[unit];
+    const task = {
+      id: Date.now(),
+      title,
+      category,
+      priority,
+      startTime: Date.now(),
+      durationMs: duration * multiplier,
+      notes,
+      done: false,
+    };
+    onAdd(task);
+    setTitle('');
+    setCategory('');
+    setPriority('low');
+    setDuration(1);
+    setUnit('minutes');
+    setNotes('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-4 space-y-2">
+      <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Titel" className="border p-1 w-full" required />
+      <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Kategorie" className="border p-1 w-full" />
+      <select value={priority} onChange={e => setPriority(e.target.value)} className="border p-1 w-full">
+        <option value="low">Low</option>
+        <option value="medium">Medium</option>
+        <option value="high">High</option>
+      </select>
+      <div className="flex space-x-2">
+        <input type="number" min="1" value={duration} onChange={e => setDuration(Number(e.target.value))} className="border p-1 w-1/2" />
+        <select value={unit} onChange={e => setUnit(e.target.value)} className="border p-1 w-1/2">
+          <option value="minutes">Minuten</option>
+          <option value="hours">Stunden</option>
+          <option value="days">Tage</option>
+        </select>
+      </div>
+      <textarea value={notes} onChange={e => setNotes(e.target.value)} placeholder="Notizen" className="border p-1 w-full"></textarea>
+      <button type="submit" className="bg-blue-500 text-white px-2 py-1">Task anlegen</button>
+    </form>
+  );
+}
+
+function TaskItem({ task, onToggle }) {
+  const [progress, setProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    const update = () => {
+      if (task.done) {
+        setProgress(1);
+        return;
+      }
+      const now = Date.now();
+      const p = Math.min((now - task.startTime) / task.durationMs, 1);
+      setProgress(p);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [task]);
+
+  const barColor = task.priority === 'high' ? 'bg-red-500' : task.priority === 'medium' ? 'bg-yellow-500' : 'bg-green-500';
+
+  return (
+    <div className="border p-2 mb-2 bg-white">
+      <div className="flex justify-between">
+        <div>
+          <h3 className="font-bold">{task.title}</h3>
+          <p className="text-sm text-gray-600">{task.category}</p>
+        </div>
+        <button onClick={() => onToggle(task.id)} className="text-sm text-blue-600">
+          {task.done ? 'Rückgängig' : 'Erledigt'}
+        </button>
+      </div>
+      <div className="h-2 bg-gray-200 mt-2">
+        <div className={`${barColor} h-full`} style={{ width: `${progress * 100}%`, transition: 'width 1s linear' }}></div>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [tasks, setTasks] = React.useState(loadTasks());
+
+  React.useEffect(() => {
+    saveTasks(tasks);
+  }, [tasks]);
+
+  const addTask = task => setTasks([...tasks, task]);
+
+  const toggleTask = id => {
+    setTasks(tasks.map(t => (t.id === id ? { ...t, done: !t.done } : t)));
+  };
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Paraström</h1>
+      <TaskForm onAdd={addTask} />
+      <div className="flex space-x-2 mb-4">
+        <button onClick={() => exportTasks(tasks)} className="bg-gray-500 text-white px-2 py-1">Export</button>
+        <button onClick={() => importTasks(setTasks)} className="bg-gray-500 text-white px-2 py-1">Import</button>
+      </div>
+      {tasks.map(task => (
+        <TaskItem key={task.id} task={task} onToggle={toggleTask} />
+      ))}
+      {/* Roadmap:
+        - Screenshots/Dokumente anhängen
+        - Web Notifications
+        - Filter/Sortierung
+        - Cloud-Sync (z.B. Firebase)
+        - Dark Mode / Themes
+        - Mehrsprachigkeit
+        - Export als PDF/CSV
+      */}
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Paraström</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="bg-gray-100 min-h-screen p-4">
+  <div id="root"></div>
+
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a single-page React app using CDN links and Tailwind
- implement task management with localStorage
- allow JSON export/import
- document how to run the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864f17e7e3c83209ef53548d4c4f491