### PR TITLE
Modernize UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,24 +78,31 @@ function TaskForm({ onAdd }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mb-4 space-y-2">
-      <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Titel" className="border p-1 w-full" required />
-      <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Kategorie" className="border p-1 w-full" />
-      <select value={priority} onChange={e => setPriority(e.target.value)} className="border p-1 w-full">
-        <option value="low">Low</option>
-        <option value="medium">Medium</option>
-        <option value="high">High</option>
-      </select>
+    <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow space-y-3 w-full max-w-md">
+      <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Titel" className="border border-gray-300 rounded p-2 w-full" required />
+      <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Kategorie" className="border border-gray-300 rounded p-2 w-full" />
       <div className="flex space-x-2">
-        <input type="number" min="1" value={duration} onChange={e => setDuration(Number(e.target.value))} className="border p-1 w-1/2" />
-        <select value={unit} onChange={e => setUnit(e.target.value)} className="border p-1 w-1/2">
+        {['low', 'medium', 'high'].map(p => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPriority(p)}
+            className={`px-3 py-1 rounded-full border text-sm flex-1 ${priority === p ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700'}`}
+          >
+            {p.charAt(0).toUpperCase() + p.slice(1)}
+          </button>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input type="number" min="1" value={duration} onChange={e => setDuration(Number(e.target.value))} className="border border-gray-300 rounded p-2 flex-1" />
+        <select value={unit} onChange={e => setUnit(e.target.value)} className="border border-gray-300 rounded p-2 w-1/2">
           <option value="minutes">Minuten</option>
           <option value="hours">Stunden</option>
           <option value="days">Tage</option>
         </select>
       </div>
-      <textarea value={notes} onChange={e => setNotes(e.target.value)} placeholder="Notizen" className="border p-1 w-full"></textarea>
-      <button type="submit" className="bg-blue-500 text-white px-2 py-1">Task anlegen</button>
+      <textarea value={notes} onChange={e => setNotes(e.target.value)} placeholder="Notizen" className="border border-gray-300 rounded p-2 w-full"></textarea>
+      <button type="submit" className="bg-teal-600 hover:bg-teal-700 text-white rounded-full px-4 py-2">Speichern</button>
     </form>
   );
 }
@@ -123,24 +130,33 @@ function TaskItem({ task, onToggle, onDelete }) {
     return () => clearInterval(id);
   }, [task]);
 
-  const barColor = task.priority === 'high' ? 'bg-red-500' : task.priority === 'medium' ? 'bg-yellow-500' : 'bg-green-500';
+  const barGradient =
+    task.priority === 'high'
+      ? 'from-red-400 to-red-600'
+      : task.priority === 'medium'
+      ? 'from-orange-400 to-orange-600'
+      : 'from-green-400 to-green-600';
 
   return (
-    <div className="border p-2 bg-white rounded shadow">
+    <div className={`border p-2 bg-white rounded shadow transition-opacity duration-300 ${task.done ? 'opacity-60' : ''}`}> 
       <div className="flex justify-between items-start mb-1">
         <div>
-          <h3 className="font-bold">{task.title}</h3>
-          <p className="text-sm text-gray-600">{task.category}</p>
+          <h3 className="font-bold flex items-center">
+            {task.title}
+            {task.category && (
+              <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-gray-200">{task.category}</span>
+            )}
+          </h3>
         </div>
         <div className="space-x-2">
-          <button onClick={() => onToggle(task.id)} className="text-sm text-blue-600">
+          <button onClick={() => onToggle(task.id)} className="text-sm text-teal-600 hover:underline">
             {task.done ? 'Rückgängig' : 'Erledigt'}
           </button>
-          <button onClick={() => onDelete(task.id)} className="text-sm text-red-600">Löschen</button>
+          <button onClick={() => onDelete(task.id)} className="text-sm text-red-600 hover:underline">Löschen</button>
         </div>
       </div>
-      <div className="h-2 bg-gray-200">
-        <div className={`${barColor} h-full`} style={{ width: `${progress * 100}%`, transition: 'width 1s linear' }}></div>
+      <div className="h-2 bg-gray-200 rounded">
+        <div className={`h-full bg-gradient-to-r ${barGradient}`} style={{ width: `${progress * 100}%`, transition: 'width 1s linear' }}></div>
       </div>
     </div>
   );
@@ -148,6 +164,7 @@ function TaskItem({ task, onToggle, onDelete }) {
 
 function App() {
   const [tasks, setTasks] = React.useState(loadTasks());
+  const [showForm, setShowForm] = React.useState(false);
 
   React.useEffect(() => {
     saveTasks(tasks);
@@ -159,8 +176,10 @@ function App() {
     }
   }, []);
 
-  const addTask = task => setTasks([...tasks, task]);
-
+  const addTask = task => {
+    setTasks([...tasks, task]);
+    setShowForm(false);
+  };
   const toggleTask = id => {
     setTasks(tasks.map(t => (t.id === id ? { ...t, done: !t.done } : t)));
   };
@@ -169,29 +188,36 @@ function App() {
     setTasks(tasks.filter(t => t.id !== id));
   };
 
+  const activeCount = tasks.filter(t => !t.done).length;
+  const doneCount = tasks.filter(t => t.done).length;
+
   return (
-    <div className="max-w-xl mx-auto">
-      <img src="logo.png" alt="Paraström" className="w-24 mx-auto mb-2" />
-      <h1 className="text-2xl font-bold mb-4 text-center">Paraström</h1>
-      <TaskForm onAdd={addTask} />
-      <div className="flex space-x-2 mb-4">
-        <button onClick={() => exportTasks(tasks)} className="bg-gray-500 text-white px-2 py-1">Export</button>
-        <button onClick={() => importTasks(setTasks)} className="bg-gray-500 text-white px-2 py-1">Import</button>
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div className="max-w-5xl mx-auto p-4">
+      <header className="flex items-center mb-4">
+        <div className="flex items-center">
+          <img src="logo.png" alt="Paraström" className="w-10 mr-2" />
+          <h1 className="text-xl font-bold">Paraström</h1>
+        </div>
+        <div className="ml-auto flex items-center space-x-2">
+          <span className="text-sm text-gray-600">{activeCount} aktiv | {doneCount} erledigt</span>
+          <button onClick={() => exportTasks(tasks)} className="p-2 bg-white rounded-full shadow text-teal-600 hover:bg-teal-50">⬇️</button>
+          <button onClick={() => importTasks(setTasks)} className="p-2 bg-white rounded-full shadow text-teal-600 hover:bg-teal-50">⬆️</button>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {tasks.map(task => (
           <TaskItem key={task.id} task={task} onToggle={toggleTask} onDelete={deleteTask} />
         ))}
       </div>
-      {/* Roadmap:
-        - Screenshots/Dokumente anhängen
-        - Web Notifications (implementiert)
-        - Filter/Sortierung
-        - Cloud-Sync (z.B. Firebase)
-        - Dark Mode / Themes
-        - Mehrsprachigkeit
-        - Export als PDF/CSV
-      */}
+
+      {showForm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+          <TaskForm onAdd={addTask} />
+        </div>
+      )}
+
+      <button onClick={() => setShowForm(true)} className="fixed bottom-4 right-4 bg-teal-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg text-2xl">+</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use cards and chips in `TaskForm`
- style tasks with gradient progress bars
- add header with counters and export/import buttons
- toggle form via floating action button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864fc72333c8320b19ec3f9d5b0cca9