### PR TITLE
Improve task export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,21 @@ Um möglichst schnell ein rundes Produkt zu erhalten, können Phase 2 und 3 komb
 
 ## Starten
 Öffne einfach die Datei `index.html` im Browser. React und Tailwind werden per CDN geladen, ein separater Build-Schritt ist nicht erforderlich.
+
+### JSON-Format
+Beim Export entsteht eine Datei mit allen Tasks. Ein Eintrag sieht zum Beispiel so aus:
+
+```json
+{
+  "id": "20230101123000",
+  "title": "Lichttraverse montieren",
+  "category": "Lichttechnik",
+  "priority": "medium",
+  "startTime": "20230101123000",
+  "durationMs": 2700000,
+  "notes": "Hängung mit Sicherheitsseilen sichern.",
+  "done": false
+}
+```
+
+`startTime` nutzt das Format `YYYYMMDDHHMMSS`. Daraus berechnet die App zusammen mit `durationMs` den Fortschritt.

--- a/app.js
+++ b/app.js
@@ -1,5 +1,30 @@
 const STORAGE_KEY = 'parastrom_tasks';
 
+function formatTimestamp(date) {
+  const pad = n => n.toString().padStart(2, '0');
+  return (
+    date.getFullYear().toString() +
+    pad(date.getMonth() + 1) +
+    pad(date.getDate()) +
+    pad(date.getHours()) +
+    pad(date.getMinutes()) +
+    pad(date.getSeconds())
+  );
+}
+
+function parseTimestamp(value) {
+  if (typeof value === 'number') return value;
+  const str = String(value);
+  if (str.length !== 14) return Date.parse(str);
+  const year = parseInt(str.slice(0, 4), 10);
+  const month = parseInt(str.slice(4, 6), 10) - 1;
+  const day = parseInt(str.slice(6, 8), 10);
+  const hour = parseInt(str.slice(8, 10), 10);
+  const min = parseInt(str.slice(10, 12), 10);
+  const sec = parseInt(str.slice(12, 14), 10);
+  return new Date(year, month, day, hour, min, sec).getTime();
+}
+
 function saveTasks(tasks) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
 }
@@ -198,12 +223,13 @@ function TaskForm({ onAdd }) {
   const handleSubmit = e => {
     e.preventDefault();
     const multiplier = { minutes: 60000, hours: 3600000, days: 86400000 }[unit];
+    const timestamp = formatTimestamp(new Date());
     const task = {
-      id: Date.now(),
+      id: timestamp,
       title,
       category,
       priority,
-      startTime: Date.now(),
+      startTime: timestamp,
       durationMs: duration * multiplier,
       notes,
       done: false,
@@ -259,7 +285,8 @@ function TaskItem({ task, onToggle, onDelete }) {
         return;
       }
       const now = Date.now();
-      const p = Math.min((now - task.startTime) / task.durationMs, 1);
+      const start = parseTimestamp(task.startTime);
+      const p = Math.min((now - start) / task.durationMs, 1);
       setProgress(p);
       if (p >= 1 && !notificationShown.current) {
         showNotification(task.title);


### PR DESCRIPTION
## Summary
- store task timestamps as `YYYYMMDDHHMMSS` strings
- use the formatted timestamp as the task id
- parse timestamp strings when displaying progress
- document the new JSON export format

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6865168f18608320bc611383c511ec72